### PR TITLE
Move #WhatNow tag from home to welcome

### DIFF
--- a/resources/assets/js/pages/home.vue
+++ b/resources/assets/js/pages/home.vue
@@ -2,7 +2,6 @@
   <b-container fluid class="home-page">
     <b-row class="p-4" v-if="user">
       <b-col cols="12">
-        <p class="whatnow-tag">#WhatNow</p>
         <h2 class="mb-3">
           {{ $t('home_pods.wellcome') }}
           {{ user.data.user_profile.first_name }}!
@@ -288,13 +287,6 @@ export default {
 }
 </script>
 <style>
-.whatnow-tag {
-  font-size: 1.1rem;
-  font-weight: 600;
-  color: #E8473F;
-  margin-bottom: 0.25rem;
-}
-
 .button-container {
   display: flex;
   justify-content: space-between;

--- a/resources/assets/js/pages/welcome.vue
+++ b/resources/assets/js/pages/welcome.vue
@@ -5,6 +5,7 @@
         <div>
           <img class="head-img mt-negative-header" :src="src('landingHead')">
           <div class="top-head">
+            <p class="whatnow-tag">#WhatNow</p>
             <h2 class="white-subtitle-top">{{ $t('landing.head_1') }}</h2>
             <h2 class="white-subtitle">{{ $t('landing.head_2') }}</h2>
             <p class="white-text mt-4 pre-line line-height-50">{{ $t('landing.head_text') }}</p>
@@ -322,6 +323,13 @@ export default {
 };
 </script>
 <style scoped>
+
+.whatnow-tag {
+  color: white;
+  font-size: 1.1rem;
+  font-weight: 600;
+  margin-bottom: 0.25rem;
+}
 
 .pre-line {
   white-space: pre-line;


### PR DESCRIPTION
Relocate the '#WhatNow' tag from resources/assets/js/pages/home.vue to resources/assets/js/pages/welcome.vue. Removed the markup and its CSS from home.vue and added the tag plus scoped styling in welcome.vue (white color, 1.1rem size, bold weight, small bottom margin) so the badge appears in the landing header instead of the home page.