### PR TITLE
Assign fixed organisations in UserTableSeeder

### DIFF
--- a/database/seeds/Access/UserTableSeeder.php
+++ b/database/seeds/Access/UserTableSeeder.php
@@ -400,6 +400,19 @@ class UserTableSeeder extends Seeder
             if ($userProfile['user_id'] == 8 || $userProfile['user_id'] == 9) {
                 $up->user->organisations()->save(factory(App\Models\Access\User\UserOrganisation::class)->make());
             }
+            $fixedOrgs = [
+                3 => ['IND'],  // IRCS WhatNow Messages app
+                4 => ['USA'],  // Test App - USA
+                6 => ['USA'],  // Test App - USA (api user)
+            ];
+
+            if (isset($fixedOrgs[$userProfile['user_id']])) {
+                foreach ($fixedOrgs[$userProfile['user_id']] as $code) {
+                    $up->user->organisations()->save(
+                        new \App\Models\Access\User\UserOrganisation(['organisation_code' => $code])
+                    );
+                }
+            }
         }
 
         DB::table('user_roles')->insert($userRoles);


### PR DESCRIPTION
Add a mapping of specific user IDs to organisation codes in database/seeds/Access/UserTableSeeder.php and create UserOrganisation records for those users during seeding. A $fixedOrgs array maps users 3, 4, and 6 to IND/USA and the seeder now iterates this mapping to save new \App\Models\Access\User\UserOrganisation instances. This ensures those test/app users get the expected organisation assignments while preserving the existing special-case logic for users 8 and 9.