### PR TITLE
Assign fixed organisations and update user access rules

### DIFF
--- a/app/Http/Controllers/WhatNow/ApplicationController.php
+++ b/app/Http/Controllers/WhatNow/ApplicationController.php
@@ -11,6 +11,7 @@ use App\Http\Resources\WhatNow\ApplicationResource;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+use Illuminate\Support\Facades\Log;
 
 
 /**
@@ -142,10 +143,27 @@ final class ApplicationController extends ApiController
         $description = $request->get('description');
         $estimatedUsers = $request->get('estimatedUsers', 0);
 
-        $userId = $request->user()->id;
+        $user = $request->user()->loadMissing('roles', 'organisations');
+        $userId = $user->id;
 
         try {
             $application = $this->client->createApplication($name, $description, $estimatedUsers, $userId);
+
+            $userRules = [
+                'can_access_legacy_whatnow' => (bool) $user->can_access_legacy_whatnow,
+                'can_access_preparedness_v2' => (bool) $user->can_access_preparedness_v2,
+            ];
+
+            $currentRole = $user->roles->first();
+            if ($currentRole && ! $currentRole->api_full_access) {
+                $userRules['allowed_country_code'] = $user->organisations->pluck('organisation_code')->values()->all();
+            }
+
+            try {
+                $this->client->updateRules($userId, $userRules);
+            } catch (\Exception $e) {
+                Log::error('Failed to update rules for user ' . $userId . ': ' . $e->getMessage());
+            }
 
             return ApplicationResource::make($application);
         } catch (RcnApiResourceNotFoundException $e) {

--- a/database/seeds/Access/UserTableSeeder.php
+++ b/database/seeds/Access/UserTableSeeder.php
@@ -400,6 +400,19 @@ class UserTableSeeder extends Seeder
             if ($userProfile['user_id'] == 8 || $userProfile['user_id'] == 9) {
                 $up->user->organisations()->save(factory(App\Models\Access\User\UserOrganisation::class)->make());
             }
+            $fixedOrgs = [
+                3 => ['IND'],  // IRCS WhatNow Messages app
+                4 => ['USA'],  // Test App - USA
+                6 => ['USA'],  // Test App - USA (api user)
+            ];
+
+            if (isset($fixedOrgs[$userProfile['user_id']])) {
+                foreach ($fixedOrgs[$userProfile['user_id']] as $code) {
+                    $up->user->organisations()->save(
+                        new \App\Models\Access\User\UserOrganisation(['organisation_code' => $code])
+                    );
+                }
+            }
         }
 
         DB::table('user_roles')->insert($userRoles);


### PR DESCRIPTION
This pull request introduces improvements to user role and organisation handling in the application creation process, as well as enhances the seeding of user-organisation relationships for specific users in the database. The main changes are grouped into user rules management and database seeding enhancements.

**User Rules Management:**

* In `ApplicationController`, after creating an application, the code now loads the user's roles and organisations, constructs a `userRules` array with specific access flags, and updates these rules via the client. If the user's current role does not have full API access, the allowed country codes are set based on their associated organisations. Errors during rule updates are logged but do not interrupt the flow.
* The `Log` facade is imported to enable error logging when rule updates fail.

**Database Seeding Enhancements:**

* In `UserTableSeeder`, specific users (IDs 3, 4, and 6) are now assigned fixed organisation codes during seeding, ensuring consistent test data for these users.